### PR TITLE
Delete the temporary jar file on exit

### DIFF
--- a/agent-loader/src/main/java/com/ea/agentloader/AgentLoader.java
+++ b/agent-loader/src/main/java/com/ea/agentloader/AgentLoader.java
@@ -284,6 +284,7 @@ public class AgentLoader
             final boolean canSetNativeMethodPrefix) throws IOException
     {
         final File jarFile = File.createTempFile("javaagent." + agentClass, ".jar");
+        jarFile.deleteOnExit();
         createAgentJar(new FileOutputStream(jarFile),
                 agentClass,
                 bootClassPath,


### PR DESCRIPTION
In order to prevent useless accumulation of temporary agent jar files in the temporary directory, request that the JVM delete the file on exit. Note that the JVM will only do so if the VM terminates normally, but at least this approach deletes the file sometimes rather than never.
