### PR TITLE
Consider OpenJDK to be a HotSpot JVM

### DIFF
--- a/agent-loader/src/main/java/com/ea/agentloader/AgentLoaderHotSpot.java
+++ b/agent-loader/src/main/java/com/ea/agentloader/AgentLoaderHotSpot.java
@@ -91,7 +91,7 @@ public class AgentLoaderHotSpot
         }
 
         String jvm = System.getProperty("java.vm.name").toLowerCase();
-        if (jvm.contains("hotspot"))
+        if (jvm.contains("hotspot") || jvm.contains("openjdk"))
         {
             // tools jar not present, but it's a sun vm
             Class<VirtualMachine> virtualMachineClass = pickVmImplementation();


### PR DESCRIPTION
OpenJDK (which uses an evolution of HotSpot) sets the system property "java.vm.name" to "OpenJDK 64-Bit Server VM" Notably, it does not include the word "hotspot" - but it does work with the AgentLoaderHotSpot method, so include support for it.
